### PR TITLE
fix bug in peekU32

### DIFF
--- a/classes/Tibia_binary_serializer.class.php
+++ b/classes/Tibia_binary_serializer.class.php
@@ -174,7 +174,7 @@ class Tibia_binary_serializer
                 return null;
             }
         }
-        return from_little_uint16_t(substr($this->buf, 0, 2));
+        return from_little_uint32_t(substr($this->buf, 0, 4));
     }
     public function peek_string(bool $exception_on_missing_header = true, bool $exception_on_invalid_header = true): ? string
     {


### PR DESCRIPTION
...  the old code would essentially give you a peekU16, meaning it would return the wrong value for anything higer than 65535 (because little-endian uint32 doesn't use the last 2 bytes for numbers lower than 65535)

sorry, my bad.