### PR TITLE
function str_with_size_header()

### DIFF
--- a/classes/Tibia_binary_serializer.class.php
+++ b/classes/Tibia_binary_serializer.class.php
@@ -17,6 +17,10 @@ class Tibia_binary_serializer
     {
         return $this->buf;
     }
+    public function str_with_size_header(): string
+    {
+        return (new Tibia_binary_serializer())->add_string($this->str())->str();
+    }
     function __construct(string $initial_buffer = "")
     {
         $this->buf = $initial_buffer;


### PR DESCRIPTION
get string with the standard cipsoft-style size header. this will get useful later, i'm already using this in private scripts.

(the implementation can be micro-optimized slightly but it should be fast regardless, and it's easier to implement this way)